### PR TITLE
Centralize Errors

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,0 +1,38 @@
+package rio
+
+import "net/http"
+
+type AppError struct {
+	Message string
+	Status  int
+	IsJson  bool
+}
+
+func (a *AppError) Error() string {
+	return a.Message
+}
+
+func (a *AppError) WriteTo(w http.ResponseWriter) error {
+	if a.IsJson {
+		return writeJson(w, a.Message, a.Status)
+	}
+
+	http.Error(w, a.Message, a.Status)
+	return nil
+}
+
+func HttpError(message string, status int) *AppError {
+	return &AppError{
+		Message: message,
+		Status:  status,
+		IsJson:  false,
+	}
+}
+
+func JsonError(message string, status int) *AppError {
+	return &AppError{
+		Message: message,
+		Status:  status,
+		IsJson:  true,
+	}
+}

--- a/handlers.go
+++ b/handlers.go
@@ -8,6 +8,40 @@ import (
 // ------------------------------------------------------------------
 //
 //
+// Basic Handlers
+//
+//
+// ------------------------------------------------------------------
+
+// BasicHttp is an http handler which serves a custom message
+// with a status of 200 OK.
+//
+//	r.Handle("/", BasicHttp("hi"))
+//
+// .
+func BasicHttp(msg string) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, msg, http.StatusOK)
+	}
+	return http.HandlerFunc(fn)
+}
+
+// BasicJson is an http handler which serves a custom json message
+// with a status of 200 OK.
+//
+//	r.Handle("/", BasicJson("hi"))
+//
+// .
+func BasicJson(msg string) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		writeJson(w, msg, http.StatusOK)
+	}
+	return http.HandlerFunc(fn)
+}
+
+// ------------------------------------------------------------------
+//
+//
 // FileServer Handlers
 //
 //

--- a/logger.go
+++ b/logger.go
@@ -15,60 +15,24 @@ import (
 //
 // ------------------------------------------------------------------
 
-var defaultLogger = NewTextLogger(os.Stdout)
+var defaultLogger = NewLogger(os.Stdout)
+
+func NewLogger(w io.Writer) *slog.Logger {
+	return slog.New(slog.NewTextHandler(w, nil))
+}
 
 func LogDebug(msg string, attrs ...slog.Attr) {
-	defaultLogger.Debug(msg, attrs...)
+	defaultLogger.LogAttrs(context.Background(), slog.LevelDebug, msg, attrs...)
 }
 
 func LogInfo(msg string, attrs ...slog.Attr) {
-	defaultLogger.Info(msg, attrs...)
+	defaultLogger.LogAttrs(context.Background(), slog.LevelInfo, msg, attrs...)
 }
 
 func LogWarn(msg string, attrs ...slog.Attr) {
-	defaultLogger.Warn(msg, attrs...)
+	defaultLogger.LogAttrs(context.Background(), slog.LevelWarn, msg, attrs...)
 }
 
 func LogError(msg string, attrs ...slog.Attr) {
-	defaultLogger.Error(msg, attrs...)
-}
-
-// ------------------------------------------------------------------
-//
-//
-// Type: Logger
-//
-//
-// ------------------------------------------------------------------
-
-type Logger struct {
-	logger *slog.Logger
-}
-
-func NewTextLogger(w io.Writer) *Logger {
-	return &Logger{
-		logger: slog.New(slog.NewTextHandler(w, nil)),
-	}
-}
-
-func NewJsonLogger(w io.Writer) *Logger {
-	return &Logger{
-		logger: slog.New(slog.NewJSONHandler(w, nil)),
-	}
-}
-
-func (l *Logger) Debug(msg string, attrs ...slog.Attr) {
-	l.logger.LogAttrs(context.Background(), slog.LevelDebug, msg, attrs...)
-}
-
-func (l *Logger) Info(msg string, attrs ...slog.Attr) {
-	l.logger.LogAttrs(context.Background(), slog.LevelInfo, msg, attrs...)
-}
-
-func (l *Logger) Warn(msg string, attrs ...slog.Attr) {
-	l.logger.LogAttrs(context.Background(), slog.LevelWarn, msg, attrs...)
-}
-
-func (l *Logger) Error(msg string, attrs ...slog.Attr) {
-	l.logger.LogAttrs(context.Background(), slog.LevelError, msg, attrs...)
+	defaultLogger.LogAttrs(context.Background(), slog.LevelError, msg, attrs...)
 }

--- a/logger.go
+++ b/logger.go
@@ -17,6 +17,10 @@ import (
 
 var defaultLogger = NewLogger(os.Stdout)
 
+func Logger(l *slog.Logger) {
+	defaultLogger = l
+}
+
 func NewLogger(w io.Writer) *slog.Logger {
 	return slog.New(slog.NewTextHandler(w, nil))
 }
@@ -33,6 +37,6 @@ func LogWarn(msg string, attrs ...slog.Attr) {
 	defaultLogger.LogAttrs(context.Background(), slog.LevelWarn, msg, attrs...)
 }
 
-func LogError(msg string, attrs ...slog.Attr) {
-	defaultLogger.LogAttrs(context.Background(), slog.LevelError, msg, attrs...)
+func LogError(err error, attrs ...slog.Attr) {
+	defaultLogger.LogAttrs(context.Background(), slog.LevelError, err.Error(), attrs...)
 }

--- a/server.go
+++ b/server.go
@@ -24,7 +24,7 @@ func NewServer() *Server {
 	s := &Server{
 		mux: http.NewServeMux(),
 	}
-	s.Use(RecoverPanic, LogRequest, SecureHeaders)
+	s.Use(LogRequest, RecoverPanic, SecureHeaders)
 	return s
 }
 

--- a/utils.go
+++ b/utils.go
@@ -46,6 +46,7 @@ func Http404(w http.ResponseWriter) {
 }
 
 func Http500(w http.ResponseWriter, err error) {
+	LogError(err.Error())
 	status := http.StatusInternalServerError
 	http.Error(w, http.StatusText(status), status)
 }
@@ -122,19 +123,19 @@ func writeJson(w http.ResponseWriter, status int, data any) {
 //
 // ------------------------------------------------------------------
 
-func SafeHTML(content string) template.HTML {
+func TmplSafeHTML(content string) template.HTML {
 	return template.HTML(content)
 }
 
-func TimeDisplay(d time.Time) string {
+func TmplTimeDisplay(d time.Time) string {
 	return d.Format("3:04 PM")
 }
 
-func DateDisplay(d time.Time) string {
+func TmplDateDisplay(d time.Time) string {
 	return d.Format("January 02, 2006")
 }
 
-func DateTimeDisplay(d time.Time) string {
+func TmplDateTimeDisplay(d time.Time) string {
 	return d.Format("January 02, 2006, 3:04 PM")
 }
 

--- a/utils.go
+++ b/utils.go
@@ -15,38 +15,31 @@ import (
 //
 // ------------------------------------------------------------------
 
-func Http200(w http.ResponseWriter) {
-	status := http.StatusOK
-	http.Error(w, http.StatusText(status), status)
+func Http200(w http.ResponseWriter, msg string) {
+	http.Error(w, msg, http.StatusOK)
 }
 
-func Http301(w http.ResponseWriter) {
-	status := http.StatusMovedPermanently
-	http.Error(w, http.StatusText(status), status)
+func Http301(w http.ResponseWriter, msg string) {
+	http.Error(w, msg, http.StatusMovedPermanently)
 }
 
-func Http400(w http.ResponseWriter) {
-	status := http.StatusBadRequest
-	http.Error(w, http.StatusText(status), status)
+func Http400(w http.ResponseWriter, msg string) {
+	http.Error(w, msg, http.StatusBadRequest)
 }
 
-func Http401(w http.ResponseWriter) {
-	status := http.StatusUnauthorized
-	http.Error(w, http.StatusText(status), status)
+func Http401(w http.ResponseWriter, msg string) {
+	http.Error(w, msg, http.StatusUnauthorized)
 }
 
-func Http403(w http.ResponseWriter) {
-	status := http.StatusForbidden
-	http.Error(w, http.StatusText(status), status)
+func Http403(w http.ResponseWriter, msg string) {
+	http.Error(w, msg, http.StatusForbidden)
 }
 
-func Http404(w http.ResponseWriter) {
-	status := http.StatusNotFound
-	http.Error(w, http.StatusText(status), status)
+func Http404(w http.ResponseWriter, msg string) {
+	http.Error(w, msg, http.StatusNotFound)
 }
 
-func Http500(w http.ResponseWriter, err error) {
-	LogError(err.Error())
+func Http500(w http.ResponseWriter) {
 	status := http.StatusInternalServerError
 	http.Error(w, http.StatusText(status), status)
 }
@@ -59,60 +52,69 @@ func Http500(w http.ResponseWriter, err error) {
 //
 // ------------------------------------------------------------------
 
-func Json200(w http.ResponseWriter, data any) {
-	writeJson(w, http.StatusOK, data)
+func Json200(w http.ResponseWriter, data any) error {
+	return writeJson(w, data, http.StatusOK)
 }
 
-func Json201(w http.ResponseWriter, data any) {
-	writeJson(w, http.StatusCreated, data)
+func Json201(w http.ResponseWriter, data any) error {
+	return writeJson(w, data, http.StatusCreated)
 }
 
-func Json204(w http.ResponseWriter, data any) {
-	writeJson(w, http.StatusNoContent, data)
+func Json204(w http.ResponseWriter, data any) error {
+	return writeJson(w, data, http.StatusNoContent)
 }
 
-func Json301(w http.ResponseWriter, data any) {
-	writeJson(w, http.StatusMovedPermanently, data)
+func Json301(w http.ResponseWriter, data any) error {
+	return writeJson(w, data, http.StatusMovedPermanently)
 }
 
-func Json400(w http.ResponseWriter, data any) {
-	writeJson(w, http.StatusBadRequest, data)
+func Json400(w http.ResponseWriter, data any) error {
+	return writeJson(w, data, http.StatusBadRequest)
 }
 
-func Json401(w http.ResponseWriter, data any) {
-	writeJson(w, http.StatusUnauthorized, data)
+func Json401(w http.ResponseWriter, data any) error {
+	return writeJson(w, data, http.StatusUnauthorized)
 }
 
-func Json403(w http.ResponseWriter, data any) {
-	writeJson(w, http.StatusForbidden, data)
+func Json403(w http.ResponseWriter, data any) error {
+	return writeJson(w, data, http.StatusForbidden)
 }
 
-func Json404(w http.ResponseWriter, data any) {
-	writeJson(w, http.StatusNotFound, data)
+func Json404(w http.ResponseWriter, data any) error {
+	return writeJson(w, data, http.StatusNotFound)
 }
 
-func Json500(w http.ResponseWriter, data any) {
-	writeJson(w, http.StatusInternalServerError, data)
+func Json500(w http.ResponseWriter) error {
+	return writeJson(w, nil, http.StatusInternalServerError)
 }
 
-func writeJson(w http.ResponseWriter, status int, data any) {
+type defaultJsonMessage struct {
+	Message string `json:"message"`
+}
+
+func writeJson(w http.ResponseWriter, data any, status int) error {
 	if data == nil {
-		data = struct {
-			Message string `json:"message"`
-		}{
+		data = defaultJsonMessage{
 			Message: http.StatusText(status),
+		}
+	}
+
+	if dataStr, ok := data.(string); ok {
+		data = defaultJsonMessage{
+			Message: dataStr,
 		}
 	}
 
 	js, err := json.Marshal(data)
 	if err != nil {
-		Http500(w, err)
-		return
+		return err
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	w.Write(js)
+
+	return nil
 }
 
 // ------------------------------------------------------------------
@@ -123,19 +125,19 @@ func writeJson(w http.ResponseWriter, status int, data any) {
 //
 // ------------------------------------------------------------------
 
-func TmplSafeHTML(content string) template.HTML {
+func DisplaySafeHTML(content string) template.HTML {
 	return template.HTML(content)
 }
 
-func TmplTimeDisplay(d time.Time) string {
+func DisplayTime(d time.Time) string {
 	return d.Format("3:04 PM")
 }
 
-func TmplDateDisplay(d time.Time) string {
+func DisplayDate(d time.Time) string {
 	return d.Format("January 02, 2006")
 }
 
-func TmplDateTimeDisplay(d time.Time) string {
+func DisplayDateTime(d time.Time) string {
 	return d.Format("January 02, 2006, 3:04 PM")
 }
 

--- a/view.go
+++ b/view.go
@@ -23,14 +23,14 @@ func Templates(templatesFS fs.FS, opts ...ViewOpt) {
 	defaultView = NewView(templatesFS, opts...)
 }
 
-func Render(w http.ResponseWriter, page string, status int, data any) {
-	defaultView.Render(w, page, status, data)
+func Render(w http.ResponseWriter, page string, status int, data any) error {
+	return defaultView.Render(w, page, status, data)
 }
 
 // ------------------------------------------------------------------
 //
 //
-// View Functional Options
+// Functional Options for View
 //
 //
 // ------------------------------------------------------------------
@@ -64,11 +64,11 @@ func NewView(templatesFS fs.FS, opts ...ViewOpt) *View {
 		funcMap:   template.FuncMap{},
 	}
 
-	// Set default functions for the func map.
-	v.funcMap["safe"] = TmplSafeHTML
-	v.funcMap["time"] = TmplTimeDisplay
-	v.funcMap["date"] = TmplDateDisplay
-	v.funcMap["datetime"] = TmplDateTimeDisplay
+	// Set default functions for the func map (from utils.go).
+	v.funcMap["safe"] = DisplaySafeHTML
+	v.funcMap["time"] = DisplayTime
+	v.funcMap["date"] = DisplayDate
+	v.funcMap["datetime"] = DisplayDateTime
 
 	// Configure with ViewOpt funcs, if any.
 	for i := range opts {
@@ -110,26 +110,19 @@ func NewView(templatesFS fs.FS, opts ...ViewOpt) *View {
 
 // Render writes a template to the http.ResponseWriter.
 // .
-func (v *View) Render(w http.ResponseWriter, page string, status int, data any) {
+func (v *View) Render(w http.ResponseWriter, page string, status int, data any) error {
 	buf := new(bytes.Buffer)
 
 	// Write the template to the buffer first.
 	// If error, then respond with a server error and return.
 	if err := v.templates.ExecuteTemplate(buf, page, data); err != nil {
-		Http500(w, err)
-		return
+		return err
 	}
 
 	w.WriteHeader(status)
 
 	// Write the contents of the buffer to the http.ResponseWriter.
 	buf.WriteTo(w)
-}
 
-func (v *View) Render404(w http.ResponseWriter, data any) {
-	v.Render(w, "404", http.StatusNotFound, data)
-}
-
-func (v *View) Render500(w http.ResponseWriter, data any) {
-	v.Render(w, "500", http.StatusInternalServerError, data)
+	return nil
 }

--- a/view.go
+++ b/view.go
@@ -65,10 +65,10 @@ func NewView(templatesFS fs.FS, opts ...ViewOpt) *View {
 	}
 
 	// Set default functions for the func map.
-	v.funcMap["safe"] = SafeHTML
-	v.funcMap["time"] = TimeDisplay
-	v.funcMap["date"] = DateDisplay
-	v.funcMap["datetime"] = DateTimeDisplay
+	v.funcMap["safe"] = TmplSafeHTML
+	v.funcMap["time"] = TmplTimeDisplay
+	v.funcMap["date"] = TmplDateDisplay
+	v.funcMap["datetime"] = TmplDateTimeDisplay
 
 	// Configure with ViewOpt funcs, if any.
 	for i := range opts {


### PR DESCRIPTION
**Summary of changes**
- Use LogRequest middleware last, so it can capture the correct status code in the response.
- Use global logger for convenience.
- Namespace template funcs.
- Create custom AppError. Centralize error handling with middleware.
- Create basic http and json handlers. Simplify util functions.