### PR TITLE
Modify the HSTS policy via the "Strict-Transport-Security" header.

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -91,7 +91,7 @@ func RecoverPanic(next http.Handler) http.Handler {
 func SecureHeaders(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Referrer-Policy", "origin-when-cross-origin")
-		w.Header().Set("Strict-Transport-Security", "max-age=5184000; includeSubDomains")
+		w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload")
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.Header().Set("X-Frame-Options", "deny")
 		w.Header().Set("X-XSS-Protection", "0")


### PR DESCRIPTION
### Summary of changes

In this PR, we're modifying the HSTS policy via the "Strict-Transport-Security" header. We are now sending the preload directive from our site.

If the site owner would like their domain to be included in the HSTS preload list maintained by Chrome (and used by Firefox and Safari), then use the header below. The preload flag indicates the site owner's consent to have their domain preloaded. The site owner still needs to then go and submit the domain to the list.

Reference: https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html