### PR TITLE
Bump go directive to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/tunedmystic/rio
 
-go 1.24.4
+go 1.26.4


### PR DESCRIPTION
Bumps the `go` directive in `go.mod` from `1.24.4` to `1.26.4`, matching the toolchain the module is built and tested against.

Note: this raises the minimum Go version consumers of the library need to `1.26.4`.

Verified: `go build ./...`, `go vet ./...`, and `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)